### PR TITLE
DISABLE_DATABASE_ENVIRONMENT_CHECK=1を追記しました#121

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 rm -f /review_app/tmp/pids/server.pid
 
 # ECS用に追記
-bundle exec rails db:migrate:reset RAILS_ENV=production
+bundle exec rails db:migrate:reset RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1
 # bundle exec rails db:create RAILS_ENV=production
 # bundle exec rails db:migrate RAILS_ENV=production
 bundle exec rails db:seed RAILS_ENV=production


### PR DESCRIPTION
- [参考記事](https://shidetake.com/heroku_reset/)