### PR TITLE
未ログイン時に記事やユーザー名をクリックしてもエラーが発生しないよう修正しました#106

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -4,9 +4,9 @@
     <% if current_user?(@user) %>
       <%= link_to "編集", edit_user_path(current_user), class: "btn btn-primary btn-lg", id: "user-edit-btn" %>
     <% else %>
-      <% if current_user.following?(@user) %>
+      <% if current_user != nil && current_user.following?(@user) %>
         <%= link_to "フォロー解除", user_relationships_path(@user.id), method: :delete, class: "btn btn-primary btn-lg", id: "follow-btn" %>
-      <% else %>
+      <% elsif current_user != nil %>
         <%= link_to "フォロー", user_relationships_path(@user.id), method: :post, class: "btn btn-primary btn-lg", id: "follow-btn" %>
       <% end %>
     <% end %>


### PR DESCRIPTION
- フォロー・フォロー解除ボタンが原因でしたので修正しました。